### PR TITLE
Set up development environment (deps, requirements.txt, AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# movie-muse
+
+## Cursor Cloud specific instructions
+
+This repo is two standalone Python 3 CLI scripts (no server, no build, no automated tests):
+
+- `download_movie_scripts.py` — scrapes movie scripts from `imsdb.com` into `movie_script_files/`. Running it directly downloads **all** ~1300 scripts (slow, hits a live third-party site). The corpus is already committed, so re-scraping is rarely needed. To smoke-test the scraper pipeline without a full crawl, run the same `requests` → `BeautifulSoup` → `html2text` steps on a single script.
+- `video_transformer.py` — transfers a reference image's luminance (LAB L channel) onto every frame of a video, writing `transformed_video.mp4`.
+
+Dependencies are installed to the user site (`pip install --user`) by the startup update script; `requirements.txt` lists them.
+
+Non-obvious caveats:
+- `video_transformer.py` is **interactive** (two `input()` prompts: video path, then image path) and calls `cv2.imshow`, which needs a display. In this headless VM, run it under a virtual display and pipe the paths, e.g.:
+  `printf '/path/video.mp4\n/path/image.png\n' | xvfb-run -a python3 video_transformer.py`
+  (`xvfb` is preinstalled on this VM but is NOT in the update script; reinstall with `sudo apt-get install -y xvfb` if missing.)
+- Under `imshow`, OpenCV prints harmless `QFontDatabase: Cannot find font directory ...` warnings — these are cosmetic and do not affect the produced video.
+- `transformed_video.mp4` is written to the repo root and is not git-ignored; delete it after testing so it isn't committed.
+- There is no linter config and no test suite in this repo.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+requests
+beautifulsoup4
+html2text
+tqdm
+opencv-python


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `movie-muse` (two standalone Python 3 CLI scripts, no server/build/tests). No existing code was modified.

- Add `requirements.txt` listing the inferred dependencies (`requests`, `beautifulsoup4`, `html2text`, `tqdm`, `opencv-python`).
- Add `AGENTS.md` with `## Cursor Cloud specific instructions` covering non-obvious run caveats (interactive prompts, `cv2.imshow` needing a display via `xvfb`, harmless Qt font warnings, and cleaning up `transformed_video.mp4`).
- Startup update script installs dependencies to the user site: `python3 -m pip install --user requests beautifulsoup4 html2text tqdm opencv-python`.

## Testing

Both scripts were run end-to-end.

- `download_movie_scripts.py` pipeline (`requests` → `BeautifulSoup` → `html2text`): parsed 1303 script links from the IMSDB index and downloaded a full single script (239 KB). Full crawl not run (downloads ~1300 scripts; corpus already committed).
- `video_transformer.py`: ran the actual script under `xvfb-run` with generated video + image inputs; produced a valid `transformed_video.mp4` (320x240, 30 frames) with the reference image's luminance applied.

[Video transformer before/after](https://cursor.com/agents/bc-9e243002-d050-4a9d-a4ba-dbacb07a4746/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftransformer_before_after.png)

Left: original frame (black background). Middle: magenta reference image. Right: transformed frame — background takes the reference's brightness while the frame keeps its own chroma.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e243002-d050-4a9d-a4ba-dbacb07a4746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e243002-d050-4a9d-a4ba-dbacb07a4746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

